### PR TITLE
pdqSort enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,19 @@ Implementation of 13 sorting algorithms in Zig
 
 | Algorithm               | Custom Comparison | Zero Allocation |
 | ----------------------- | ----------------- | --------------- |
-| Quick                   | ✅                | ✅              |
-| Insertion               | ✅                | ✅              |
-| Selection               | ✅                | ✅              |
 | Bubble                  | ✅                | ✅              |
-| Shell                   | ✅                | ✅              |
 | Comb                    | ✅                | ✅              |
 | Heap                    | ✅                | ✅              |
+| Insertion               | ✅                | ✅              |
 | Merge                   | ✅                | ❌              |
+| PDQ                     | ✅                | ✅              |
+| Quick                   | ✅                | ✅              |
+| Radix (no negative yet) | ❌                | ❌              |
+| Selection               | ✅                | ✅              |
+| Shell                   | ✅                | ✅              |
 | Tail                    | ✅                | ❌              |
 | Tim                     | ✅                | ❌              |
 | Twin                    | ✅                | ❌              |
-| Radix (no negative yet) | ❌                | ❌              |
 
 ## Usage
 
@@ -42,15 +43,15 @@ gantt
     dateFormat x
     axisFormat %S s
     tim 0.617: 0,617
-    quick 2.596: 0,2595
-    radix 2.297: 0,2297
-    tail 3.199: 0,3199
-    twin 3.148: 0,3149
-    std_block_merge 4.281: 0,4281
-    comb 4.730: 0,4731
-    shell 7.633: 0,7634
+    pdq 1.306: 0,1306
+    quick 2.553: 0,2552
+    radix 2.439: 0,2441
+    tail 3.232: 0,3232
+    twin 3.248: 0,3248
+    std_block_merge 4.285: 0,4283
+    comb 4.746: 0,4747
+    shell 7.645: 0,7643
 ```
-
 ### Intel(R) Core(TM) i5-6300U CPU @ 2.40GHz
 
 ```mermaid
@@ -58,14 +59,15 @@ gantt
     title Sorting 10 million items
     dateFormat x
     axisFormat %S s
-    tim 0.241: 0,241
-    quick 1.352: 0,1352
-    radix 1.273: 0,1273
-    tail 1.633: 0,1633
-    twin 1.607: 0,1607
-    std_block_merge 2.117: 0,2118
-    comb 1.985: 0,1985
-    shell 2.916: 0,2917
+    tim 0.215: 0,215
+    pdq 0.503: 0,503
+    quick 1.152: 0,1152
+    radix 1.101: 0,1101
+    tail 1.396: 0,1396
+    twin 1.401: 0,1401
+    std_block_merge 1.594: 0,1594
+    comb 1.741: 0,1741
+    shell 2.500: 0,2501
 ```
 
 ### Intel(R) Core(TM) i7-4600U CPU @ 2.10GHz

--- a/src/pdqsort.zig
+++ b/src/pdqsort.zig
@@ -58,7 +58,7 @@ fn recurse(
         // If too many bad pivot choices were made, simply fall back to heapsort in order to
         // guarantee `O(n log n)` worst-case.
         if (limit == 0) {
-            zort.heapSort(T, items, context, cmp);
+            heapify(T, items, context, cmp);
             return;
         }
 
@@ -113,6 +113,16 @@ fn recurse(
     }
 }
 
+fn heapify(
+    comptime T: anytype,
+    items: []T,
+    context: anytype,
+    comptime cmp: fn (context: @TypeOf(context), lhs: T, rhs: T) bool,
+) void {
+    @setCold(true);
+    zort.heapSort(T, items, context, cmp);
+}
+
 /// partition partitions `items` into elements smaller than `items[pivot_idx]`,
 /// followed by elements greater than or equal to `items[pivot_idx]`.
 ///
@@ -127,6 +137,8 @@ fn partition(
     cmp: fn (context: @TypeOf(context), lhs: T, rhs: T) bool,
 ) usize {
     const pivot = items[pivot_idx];
+
+    // move pivot to the first place
     std.mem.swap(T, &items[0], &items[pivot_idx]);
 
     var i: usize = 1;
@@ -135,7 +147,9 @@ fn partition(
     while (i <= j and cmp(context, items[i], pivot)) i += 1;
     while (i <= j and !cmp(context, items[j], pivot)) j -= 1;
 
+    // Check if items are already partitioned (no item to swap)
     if (i > j) {
+        // put pivot back to the middle
         std.mem.swap(T, &items[j], &items[0]);
         was_partitioned.* = true;
         return j;
@@ -153,6 +167,7 @@ fn partition(
         std.mem.swap(T, &items[i], &items[j]);
     }
 
+    // put pivot back to the middle
     std.mem.swap(T, &items[j], &items[0]);
     was_partitioned.* = false;
     return j;
@@ -167,6 +182,7 @@ fn next(r: *XorShift) usize {
 }
 
 fn breakPatterns(comptime T: anytype, items: []T) void {
+    @setCold(true);
     if (items.len < 8) return;
 
     var r: XorShift = @intCast(XorShift, items.len);
@@ -219,6 +235,7 @@ fn partitionEqual(
 // partialInsertionSort partially sorts a slice by shifting several out-of-order elements around.
 // Returns `true` if the slice is sorted at the end. This function is `O(n)` worst-case.
 fn partialInsertionSort(comptime T: anytype, items: []T) bool {
+    @setCold(true);
     // maximum number of adjacent out-of-order pairs that will get shifted
     const max_steps = 5;
 

--- a/src/pdqsort.zig
+++ b/src/pdqsort.zig
@@ -78,7 +78,7 @@ fn recurse(
         if (was_balanced and was_partitioned and likely_sorted) {
             // Try identifying several out-of-order elements and shifting them to correct
             // positions. If the slice ends up being completely sorted, we're done.
-            if (partialInsertionSort(T, items)) return;
+            if (partialInsertionSort(T, items, context, cmp)) return;
         }
 
         // If the chosen pivot is equal to the predecessor, then it's the smallest element in the
@@ -234,7 +234,12 @@ fn partitionEqual(
 
 // partialInsertionSort partially sorts a slice by shifting several out-of-order elements around.
 // Returns `true` if the slice is sorted at the end. This function is `O(n)` worst-case.
-fn partialInsertionSort(comptime T: anytype, items: []T) bool {
+fn partialInsertionSort(
+    comptime T: anytype,
+    items: []T,
+    context: anytype,
+    cmp: fn (context: @TypeOf(context), lhs: T, rhs: T) bool,
+) bool {
     @setCold(true);
     // maximum number of adjacent out-of-order pairs that will get shifted
     const max_steps = 5;
@@ -246,7 +251,7 @@ fn partialInsertionSort(comptime T: anytype, items: []T) bool {
     var k: usize = 0;
     while (k < max_steps) : (k += 1) {
         // Find the next pair of adjacent out-of-order elements.
-        while (i < items.len and items[i] >= items[i - 1]) i += 1;
+        while (i < items.len and !cmp(context, items[i], items[i - 1])) i += 1;
 
         // Are we done?
         if (i == items.len) return true;


### PR DESCRIPTION
Hi Ali,

- I have added cold path annotation here and there (I did not notice any performance gain, but the rust standard library has them too, so it will not hurt IMO).
- Fixed a bug which caused `partialInsertationSort()` to return `true` when it should not.
- Added [BlockQuickSort](http://drops.dagstuhl.de/opus/volltexte/2016/6389/pdf/LIPIcs-ESA-2016-38.pdf) optimization which doubles the speed of `pdqSort()` on random integers. My version of `pdqSort()` is still slower than `timSort()` which should be the other way around as the latter one is a stable sort, but right now I have no idea what to do better.

Thanks,